### PR TITLE
Add support for getAll() and default 'readonly' mode to transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Unit tested mock implementation of the browser IndexedDB API. Conforms as closel
 - Enforcing constraint for unique indexes (throw `DOMException('DataError')` on `put()` and `add()` etc).
 - Indexes with array (multiple) keypaths and support for the `multiEntry` flag.
 
-**Please note:** This mock does not support any functionality added in the 2.0 spec, such as `getAll()`, `getKey()`, `getAllKeys()` and `openKeyCursor()`
+**Please note:**
+This mock supports the `getAll()` method without any optional params, functionality added in the 2.0 spec, but it does not support other functionality added in the 2.0 spec, such as `getKey()`, `getAllKeys()` and `openKeyCursor()`
 
 ## Installation
 

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -109,7 +109,7 @@ const storage = {}; // Root storage.
 			connections[dbName].push(this);
 
 			// Create a transaction on this database that accesses one or more stores.
-			function transaction(storeNames, mode)
+			function transaction(storeNames, mode = 'readonly')
 			{
 				// Check params.
 				if (typeof storeNames === 'string') storeNames = [storeNames];

--- a/lib/mock.js
+++ b/lib/mock.js
@@ -662,6 +662,7 @@ const storage = {}; // Root storage.
 			// Methods.
 			Object.defineProperty(this, 'count', { value: count });
 			Object.defineProperty(this, 'get', { value: get });
+			Object.defineProperty(this, 'getAll', { value: getAll });
 			Object.defineProperty(this, 'openCursor', { value: openCursor });
 			Object.defineProperty(this, 'put', { value: put });
 			Object.defineProperty(this, 'add', { value: add });
@@ -721,6 +722,27 @@ const storage = {}; // Root storage.
 
 				});
 			}
+
+			// Get all results.
+			// Returns a request that fires a 'success' event when its result is available.
+			// `request.result` will be an array of all the records found in an object store
+			function getAll() {
+				// Check state.
+				if (transaction._finished) throw new DOMException('IDBIndex.getAll(): Transaction has finished', 'InvalidStateError');
+
+				// Return an IDBRequest on the transaction.
+				return transaction._request(store, request => {
+
+					// Check state.
+					if (transaction._finished) throw new DOMException('IDBObjectStore.getAll(): Transaction has finished', 'InvalidStateError');
+					if (!transaction._data[storeName]) throw new DOMException('IDBIndex.getAll(): Object store \'' + storeName + '\' does not exist', 'InvalidStateError');
+
+					// Return the records found in the store.
+					const values = Array.from(transaction._data[storeName].records.values());
+					return values;
+				});
+			}
+
 
 			// Open a cursor to retrieve several results.
 			// Returns a request that fires one or more 'success' events when its results is available.

--- a/test/mock-store.test.js
+++ b/test/mock-store.test.js
@@ -509,7 +509,6 @@ describe('IndexedDB mock object store', () => {
 			e.target.result.createObjectStore('store', { keyPath: null, autoIncrement: false });
 
 		});
-		let allRequest;
 		request.onsuccess = jest.fn(e => {
 
 			// Put.
@@ -518,8 +517,8 @@ describe('IndexedDB mock object store', () => {
 			e.target.result.transaction('store', 'readwrite').objectStore('store').put({v:3}, 3);
 
 			// Get.
-			allRequest = e.target.result.transaction('store', 'readonly').objectStore('store').getAll();
-			expect(allRequest).toBeInstanceOf(IDBRequest);
+			const request = e.target.result.transaction('store', 'readonly').objectStore('store').getAll();
+			expect(request).toBeInstanceOf(IDBRequest);
 			request.onsuccess = success;
 
 		});

--- a/test/mock-store.test.js
+++ b/test/mock-store.test.js
@@ -494,6 +494,44 @@ describe('IndexedDB mock object store', () => {
 		expect(storeoutlinesuccess).toHaveBeenCalled();
 
 	});
+	test('getAll(): Get all records from object store', () => {
+
+		// Handlers.
+		const success = jest.fn(e => {
+			expect(e.target.result).toEqual([{a:1,b:2,c:3}, {a:2,b:3,c:4}, {a:3,b:4,c:5}]);
+		});
+
+		// Events.
+		const request = indexedDB.open('testing', 1);
+		request.onupgradeneeded = jest.fn(e => {
+
+			// Create object store.
+			e.target.result.createObjectStore('store', { keyPath: null, autoIncrement: false });
+
+		});
+		request.onsuccess = jest.fn(e => {
+
+			// Put.
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:1,b:2,c:3});
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:2,b:3,c:4});
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:3,b:4,c:5});
+
+			// Get.
+			const request = e.target.result.transaction('store', 'readonly').objectStore('store').getAll();
+			expect(request).toBeInstanceOf(IDBRequest);
+			request.onsuccess = success;
+
+		});
+
+		// Run.
+		jest.runAllTimers();
+
+		// Check handlers.
+		expect(request.onupgradeneeded).toHaveBeenCalled();
+		expect(request.onsuccess).toHaveBeenCalled();
+		expect(success).toHaveBeenCalled();
+
+	});
 	test('openCursor(): Get record from object store by cursor (outline key)', () => {
 
 		// Handlers.

--- a/test/mock-store.test.js
+++ b/test/mock-store.test.js
@@ -498,7 +498,7 @@ describe('IndexedDB mock object store', () => {
 
 		// Handlers.
 		const success = jest.fn(e => {
-			expect(e.target.result).toEqual([{a:1,b:2,c:3}, {a:2,b:3,c:4}, {a:3,b:4,c:5}]);
+			expect(e.target.result).toEqual([{v:1},{v:2},{v:3}]);
 		});
 
 		// Events.
@@ -509,16 +509,17 @@ describe('IndexedDB mock object store', () => {
 			e.target.result.createObjectStore('store', { keyPath: null, autoIncrement: false });
 
 		});
+		let allRequest;
 		request.onsuccess = jest.fn(e => {
 
 			// Put.
-			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:1,b:2,c:3});
-			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:2,b:3,c:4});
-			e.target.result.transaction('store', 'readwrite').objectStore('store').put({a:3,b:4,c:5});
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({v:1}, 1);
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({v:2}, 2);
+			e.target.result.transaction('store', 'readwrite').objectStore('store').put({v:3}, 3);
 
 			// Get.
-			const request = e.target.result.transaction('store', 'readonly').objectStore('store').getAll();
-			expect(request).toBeInstanceOf(IDBRequest);
+			allRequest = e.target.result.transaction('store', 'readonly').objectStore('store').getAll();
+			expect(allRequest).toBeInstanceOf(IDBRequest);
 			request.onsuccess = success;
 
 		});
@@ -530,7 +531,6 @@ describe('IndexedDB mock object store', () => {
 		expect(request.onupgradeneeded).toHaveBeenCalled();
 		expect(request.onsuccess).toHaveBeenCalled();
 		expect(success).toHaveBeenCalled();
-
 	});
 	test('openCursor(): Get record from object store by cursor (outline key)', () => {
 


### PR DESCRIPTION
This PR proposes 2 main changes:

- adding support for `getAll` method (introduced in the v2 of the IndexedDB API, which is currently missing in this implementation)
- adding the default `readonly` mode to `transaction`, consistent with the IndexedDB API specs